### PR TITLE
Probe fixes

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -718,11 +718,12 @@ int dmatest_chan_set(const char *val)
 #endif
 	struct dmatest_info *info = &test_info;
 	struct dmatest_chan *dtc;
-	char chan_reset_val[20];
+	char chan_reset_val[CHANNEL_NAME_LEN];
 	int ret = 0;
 
 	mutex_lock(&info->lock);
-	memcpy(test_channel, val, 20);
+	BUG_ON(strlen(val) >= CHANNEL_NAME_LEN);
+	strcpy(test_channel, val);
 
 	/* Reject channels that are already registered */
 	list_for_each_entry(dtc, &info->channels, node) {

--- a/dma.h
+++ b/dma.h
@@ -44,6 +44,8 @@ static unsigned int transfer_size = 1024;
 // Use polling for completion instead of interrupts
 static bool polled = true;
 
+#define CHANNEL_NAME_LEN 20
+
 /**
  * struct dmatest_params - test parameters.
  * @buf_size:		size of the memcpy test buffer
@@ -56,7 +58,7 @@ static bool polled = true;
  */
 struct dmatest_params {
 	unsigned int buf_size;
-	char channel[20];
+	char channel[CHANNEL_NAME_LEN];
 	char device[32];
 	unsigned int max_channels;
 	int timeout;
@@ -117,7 +119,7 @@ struct dmatest_chan {
 	struct list_head threads;
 };
 
-static char test_channel[20];
+static char test_channel[CHANNEL_NAME_LEN];
 
 /* Maximum amount of mismatched bytes in buffer to print */
 #define MAX_ERROR_COUNT 32

--- a/pci.c
+++ b/pci.c
@@ -107,6 +107,7 @@ void nvmev_proc_bars(void)
 		memcpy(&old_bar->csts, &bar->csts, sizeof(old_bar->csts));
 	}
 #endif
+#if 0 /* Unused registers */
 	if (old_bar->intms != bar->intms) {
 		memcpy(&old_bar->intms, &bar->intms, sizeof(old_bar->intms));
 	}
@@ -116,6 +117,7 @@ void nvmev_proc_bars(void)
 	if (old_bar->nssr != bar->nssr) {
 		memcpy(&old_bar->nssr, &bar->nssr, sizeof(old_bar->nssr));
 	}
+#endif
 	if (old_bar->aqa != bar->u_aqa) {
 		// Initalize admin queue
 		memcpy(&old_bar->aqa, &bar->aqa, sizeof(old_bar->aqa));

--- a/pci.c
+++ b/pci.c
@@ -125,7 +125,7 @@ void nvmev_proc_bars(void)
 #endif
 	if (old_bar->aqa != bar->u_aqa) {
 		// Initalize admin queue
-		memcpy(&old_bar->aqa, &bar->aqa, sizeof(old_bar->aqa));
+		old_bar->aqa = bar->u_aqa;
 
 		queue = kzalloc(sizeof(struct nvmev_admin_queue), GFP_KERNEL);
 
@@ -143,7 +143,7 @@ void nvmev_proc_bars(void)
 		modified = true;
 	}
 	if (old_bar->asq != bar->u_asq) {
-		memcpy(&old_bar->asq, &bar->asq, sizeof(old_bar->asq));
+		old_bar->asq = bar->u_asq;
 
 		queue = nvmev_vdev->admin_q;
 
@@ -168,7 +168,7 @@ void nvmev_proc_bars(void)
 		modified = true;
 	}
 	if (old_bar->acq != bar->u_acq) {
-		memcpy(&old_bar->acq, &bar->acq, sizeof(old_bar->acq));
+		old_bar->acq = bar->u_acq;
 
 		queue = nvmev_vdev->admin_q;
 
@@ -215,7 +215,7 @@ void nvmev_proc_bars(void)
 			nvmev_vdev->admin_q->cq_head = 0;
 		}
 
-		memcpy(&old_bar->cc, &bar->cc, sizeof(old_bar->cc));
+		old_bar->cc = bar->u_cc;
 
 		modified = true;
 	}


### PR DESCRIPTION
Hi, everyone.

This pull-request is to fix some probe issues that I've encountered randomly when testing NVMeVirt.

Many of those were caught using KASAN.
In case this was developed without using KASAN, I highly encourage the authors to try it out. It's really handy for discovering nasty memory bugs lurking around.

Plus, some issues were only present on weak memory model architectures.

I hope people can find this useful for reducing the number of reboots while testing NVMeVirt.

Thanks :)