### PR TITLE
ZNS initialization fixes

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -220,8 +220,13 @@ static void __nvmev_admin_get_log_page(int eid, int cq_head)
 			},
 			.iocs = {
 #if BASE_SSD == ZNS_PROTOTYPE
-				/* Zone Append is unsupported at the moment */
-				// [nvme_cmd_zone_append] = cpu_to_le32(NVME_CMD_EFFECTS_CSUPP),
+				/*
+				 * Zone Append is unsupported at the moment, but we fake it so that
+				 * Linux device driver doesn't lock it to R/O.
+				 *
+				 * A zone append command will result in device failure.
+				 */
+				[nvme_cmd_zone_append] = cpu_to_le32(NVME_CMD_EFFECTS_CSUPP),
 				[nvme_cmd_zone_mgmt_send] = cpu_to_le32(NVME_CMD_EFFECTS_CSUPP | NVME_CMD_EFFECTS_LBCC),
 				[nvme_cmd_zone_mgmt_recv] = cpu_to_le32(NVME_CMD_EFFECTS_CSUPP),
 #endif

--- a/admin.c
+++ b/admin.c
@@ -204,7 +204,7 @@ static void __nvmev_admin_get_log_page(int eid, int cq_head)
 
 		NVMEV_INFO("Handling NVME_LOG_SMART\n");
 
-		memcpy(page, &smart_log, len);
+		__memcpy(page, &smart_log, len);
 		break;
 	}
 	case NVME_LOG_CMD_EFFECTS: {
@@ -231,7 +231,7 @@ static void __nvmev_admin_get_log_page(int eid, int cq_head)
 
 		NVMEV_INFO("Handling NVME_LOG_CMD_EFFECTS\n");
 
-		memcpy(page, &effects_log, len);
+		__memcpy(page, &effects_log, len);
 		break;
 	}
 	}

--- a/admin.c
+++ b/admin.c
@@ -234,6 +234,22 @@ static void __nvmev_admin_get_log_page(int eid, int cq_head)
 		__memcpy(page, &effects_log, len);
 		break;
 	}
+	default:
+		/*
+		 * The NVMe protocol mandates several commands (lid) to be implemented, but some
+		 * aren't in NVMeVirt.
+		 *
+		 * As the NVMe host device driver will always assume that the device will return
+		 * the correct values, blindly memset'ing the return buffer will always result in
+		 * heavy system malfunction due to incorrect memory dereferences.
+		 *
+		 * Warn the users and make it perfectly clear that this needs to be implemented.
+		 */
+		NVMEV_ERROR("Unimplemented log page identifier: 0x%hhx,"
+			    "the system will be unstable!\n",
+			    cmd->lid);
+		__memset(page, 0, len);
+		break;
 	}
 
 	cq_entry(cq_head).command_id = sq_entry(eid).features.command_id;

--- a/conv_ftl.c
+++ b/conv_ftl.c
@@ -1030,16 +1030,9 @@ bool conv_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req, struc
 	case nvme_cmd_flush:
 		conv_flush(ns, req, ret);
 		break;
-	case nvme_cmd_write_uncor:
-	case nvme_cmd_compare:
-	case nvme_cmd_write_zeroes:
-	case nvme_cmd_dsm:
-	case nvme_cmd_resv_register:
-	case nvme_cmd_resv_report:
-	case nvme_cmd_resv_acquire:
-	case nvme_cmd_resv_release:
-		break;
 	default:
+		NVMEV_ERROR("%s: unimplemented command: %s(%d)\n", __func__,
+			   nvme_opcode_string(cmd->common.opcode), cmd->common.opcode);
 		break;
 	}
 

--- a/io.c
+++ b/io.c
@@ -718,7 +718,7 @@ void NVMEV_IO_PROC_INIT(struct nvmev_dev *nvmev_vdev)
 
 		snprintf(pi->thread_name, sizeof(pi->thread_name), "nvmev_proc_io_%d", proc_idx);
 
-		pi->nvmev_io_worker = kthread_create(nvmev_kthread_io, pi, pi->thread_name);
+		pi->nvmev_io_worker = kthread_create(nvmev_kthread_io, pi, "%s", pi->thread_name);
 
 		kthread_bind(pi->nvmev_io_worker, nvmev_vdev->config.cpu_nr_proc_io[proc_idx]);
 		wake_up_process(pi->nvmev_io_worker);

--- a/kv_ftl.c
+++ b/kv_ftl.c
@@ -987,15 +987,9 @@ bool kv_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req, struct 
 		NVMEV_INFO("%d, %llu, %llu\n", cmd_value_length(*((struct nvme_kv_command *)cmd)),
 			   __get_wallclock(), ret->nsecs_target);
 		break;
-	case nvme_cmd_write_uncor:
-	case nvme_cmd_compare:
-	case nvme_cmd_write_zeroes:
-	case nvme_cmd_dsm:
-	case nvme_cmd_resv_register:
-	case nvme_cmd_resv_report:
-	case nvme_cmd_resv_acquire:
-	case nvme_cmd_resv_release:
 	default:
+		NVMEV_ERROR("%s: unimplemented command: %s(%d)\n", __func__,
+			   nvme_opcode_string(cmd->common.opcode), cmd->common.opcode);
 		break;
 	}
 

--- a/nvme.h
+++ b/nvme.h
@@ -241,6 +241,22 @@ struct nvme_smart_log {
 };
 
 enum {
+	NVME_CMD_EFFECTS_CSUPP = 1 << 0,
+	NVME_CMD_EFFECTS_LBCC = 1 << 1,
+	NVME_CMD_EFFECTS_NCC = 1 << 2,
+	NVME_CMD_EFFECTS_NIC = 1 << 3,
+	NVME_CMD_EFFECTS_CCC = 1 << 4,
+	NVME_CMD_EFFECTS_CSE_MASK = 3 << 16,
+	NVME_CMD_EFFECTS_UUID_SEL = 1 << 19,
+};
+
+struct nvme_effects_log {
+	__le32 acs[256];
+	__le32 iocs[256];
+	__u8 resv[2048];
+};
+
+enum {
 	NVME_SMART_CRIT_SPARE = 1 << 0,
 	NVME_SMART_CRIT_TEMPERATURE = 1 << 1,
 	NVME_SMART_CRIT_RELIABILITY = 1 << 2,
@@ -421,11 +437,24 @@ enum nvme_admin_opcode {
 	nvme_admin_set_features = 0x09,
 	nvme_admin_get_features = 0x0a,
 	nvme_admin_async_event = 0x0c,
+	nvme_admin_ns_mgmt = 0x0d,
 	nvme_admin_activate_fw = 0x10,
 	nvme_admin_download_fw = 0x11,
+	nvme_admin_dev_self_test = 0x14,
+	nvme_admin_ns_attach = 0x15,
+	nvme_admin_keep_alive = 0x18,
+	nvme_admin_directive_send = 0x19,
+	nvme_admin_directive_recv = 0x1a,
+	nvme_admin_virtual_mgmt = 0x1c,
+	nvme_admin_nvme_mi_send = 0x1d,
+	nvme_admin_nvme_mi_recv = 0x1e,
+	nvme_admin_dbbuf = 0x7C,
 	nvme_admin_format_nvm = 0x80,
 	nvme_admin_security_send = 0x81,
 	nvme_admin_security_recv = 0x82,
+	nvme_admin_sanitize_nvm = 0x84,
+	nvme_admin_get_lba_status = 0x86,
+	nvme_admin_vendor_start = 0xC0,
 };
 
 enum {
@@ -454,6 +483,14 @@ enum {
 	NVME_LOG_ERROR = 0x01,
 	NVME_LOG_SMART = 0x02,
 	NVME_LOG_FW_SLOT = 0x03,
+	NVME_LOG_CHANGED_NS = 0x04,
+	NVME_LOG_CMD_EFFECTS = 0x05,
+	NVME_LOG_DEVICE_SELF_TEST = 0x06,
+	NVME_LOG_TELEMETRY_HOST = 0x07,
+	NVME_LOG_TELEMETRY_CTRL = 0x08,
+	NVME_LOG_ENDURANCE_GROUP = 0x09,
+	NVME_LOG_ANA = 0x0c,
+	NVME_LOG_DISC = 0x70,
 	NVME_LOG_RESERVATION = 0x80,
 	NVME_FWACT_REPL = (0 << 3),
 	NVME_FWACT_REPL_ACTV = (1 << 3),

--- a/nvme.h
+++ b/nvme.h
@@ -334,6 +334,31 @@ struct nvme_rw_command {
 	__le16 appmask;
 };
 
+struct nvme_get_log_page_command {
+	__u8 opcode;
+	__u8 flags;
+	__u16 command_id;
+	__le32 nsid;
+	__u64 rsvd2[2];
+	__le64 prp1;
+	__le64 prp2;
+	__u8 lid;
+	__u8 lsp; /* upper 4 bits reserved */
+	__le16 numdl;
+	__le16 numdu;
+	__u16 rsvd11;
+	union {
+		struct {
+			__le32 lpol;
+			__le32 lpou;
+		};
+		__le64 lpo;
+	};
+	__u8 rsvd14[3];
+	__u8 csi;
+	__u32 rsvd15;
+};
+
 enum {
 	NVME_RW_LR = 1 << 15,
 	NVME_RW_FUA = 1 << 14,
@@ -534,6 +559,7 @@ struct nvme_command {
 	union {
 		struct nvme_common_command common;
 		struct nvme_rw_command rw;
+		struct nvme_get_log_page_command get_log_page;
 		struct nvme_identify identify;
 		struct nvme_features features;
 		struct nvme_create_cq create_cq;

--- a/nvme.h
+++ b/nvme.h
@@ -306,19 +306,36 @@ struct nvme_reservation_status {
 
 /* I/O commands */
 
+#define NVME_OPCODES(op)			\
+	op(nvme_cmd_flush, 0x00)		\
+	op(nvme_cmd_write, 0x01)		\
+	op(nvme_cmd_read, 0x02)			\
+	op(nvme_cmd_write_uncor, 0x04)		\
+	op(nvme_cmd_compare, 0x05)		\
+	op(nvme_cmd_write_zeroes, 0x08)		\
+	op(nvme_cmd_dsm, 0x09)			\
+	op(nvme_cmd_verify, 0x0c)		\
+	op(nvme_cmd_resv_register, 0x0d)	\
+	op(nvme_cmd_resv_report, 0x0e)		\
+	op(nvme_cmd_resv_acquire, 0x11)		\
+	op(nvme_cmd_resv_release, 0x15)		\
+	op(nvme_cmd_zone_mgmt_send, 0x79)	\
+	op(nvme_cmd_zone_mgmt_recv, 0x7a)	\
+	op(nvme_cmd_zone_append, 0x7d)
+
+#define ENUM_NVME_OP(name, value) name = value,
+#define STRING_NVME_OP(name, value) [name] = #name,
+
 enum nvme_opcode {
-	nvme_cmd_flush = 0x00,
-	nvme_cmd_write = 0x01,
-	nvme_cmd_read = 0x02,
-	nvme_cmd_write_uncor = 0x04,
-	nvme_cmd_compare = 0x05,
-	nvme_cmd_write_zeroes = 0x08,
-	nvme_cmd_dsm = 0x09,
-	nvme_cmd_resv_register = 0x0d,
-	nvme_cmd_resv_report = 0x0e,
-	nvme_cmd_resv_acquire = 0x11,
-	nvme_cmd_resv_release = 0x15,
+	NVME_OPCODES(ENUM_NVME_OP)
 };
+
+static const char *const __nvme_opcode_strings[] = {
+	NVME_OPCODES(STRING_NVME_OP)
+};
+
+#define nvme_opcode_string(opcode) \
+	(__nvme_opcode_strings[opcode] ? __nvme_opcode_strings[opcode] : "unknown")
 
 struct nvme_common_command {
 	__u8 opcode;

--- a/nvme_zns.h
+++ b/nvme_zns.h
@@ -48,13 +48,6 @@ struct nvme_id_zns_ns {
 	__u8 vs[256];
 };
 
-/* IO command */
-enum nvme_opcode_zns {
-	nvme_cmd_zone_mgmt_send = 0x79,
-	nvme_cmd_zone_mgmt_recv = 0x7a,
-	nvme_cmd_zone_append = 0x7d,
-};
-
 enum {
 	NVME_SC_ZNS_INVALID_ZONE_OPERATION = ((NVME_SCT_CMD_SPECIFIC_STATUS << 8) | 0xB6),
 	NVME_SC_ZNS_ZRWA_RSRC_UNAVAIL,

--- a/simple_ftl.c
+++ b/simple_ftl.c
@@ -102,15 +102,9 @@ bool simple_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req,
 	case nvme_cmd_flush:
 		ret->nsecs_target = __schedule_flush(req);
 		break;
-	case nvme_cmd_write_uncor:
-	case nvme_cmd_compare:
-	case nvme_cmd_write_zeroes:
-	case nvme_cmd_dsm:
-	case nvme_cmd_resv_register:
-	case nvme_cmd_resv_report:
-	case nvme_cmd_resv_acquire:
-	case nvme_cmd_resv_release:
 	default:
+		NVMEV_ERROR("%s: unimplemented command: %s(%d)\n", __func__,
+			   nvme_opcode_string(cmd->common.opcode), cmd->common.opcode);
 		break;
 	}
 

--- a/zns_ftl.c
+++ b/zns_ftl.c
@@ -30,7 +30,7 @@ static void __init_descriptor(struct zns_ftl *zns_ftl)
 
 	zns_ftl->zone_descs = kmalloc(sizeof(struct zone_descriptor) * nr_zones, GFP_KERNEL);
 	zns_ftl->report_buffer = kmalloc(sizeof(struct zone_report) +
-						 sizeof(struct zone_descriptor) * (nr_zones - 1),
+						 sizeof(struct zone_descriptor) * nr_zones,
 					 GFP_KERNEL);
 	zns_ftl->zwra_buffer = kmalloc(sizeof(struct buffer) * nr_zones, GFP_KERNEL);
 

--- a/zns_ftl.c
+++ b/zns_ftl.c
@@ -179,15 +179,6 @@ bool zns_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req, struct
 	case nvme_cmd_flush:
 		zns_flush(ns, req, ret);
 		break;
-	case nvme_cmd_write_uncor:
-	case nvme_cmd_compare:
-	case nvme_cmd_write_zeroes:
-	case nvme_cmd_dsm:
-	case nvme_cmd_resv_register:
-	case nvme_cmd_resv_report:
-	case nvme_cmd_resv_acquire:
-	case nvme_cmd_resv_release:
-		break;
 	case nvme_cmd_zone_mgmt_send:
 		zns_zmgmt_send(ns, req, ret);
 		break;
@@ -195,7 +186,10 @@ bool zns_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req, struct
 		zns_zmgmt_recv(ns, req, ret);
 		break;
 	case nvme_cmd_zone_append:
+		NVMEV_INFO("Zone Append is not implemented yet!\n");
 	default:
+		NVMEV_ERROR("%s: unimplemented command: %s(%d)\n", __func__,
+			   nvme_opcode_string(cmd->common.opcode), cmd->common.opcode);
 		break;
 	}
 


### PR DESCRIPTION
The existing get_log_page implementation can trigger malfunctions, especially under the ZNS configuration.

This PR addresses it by fixing memory accesses and implementing NVME_LOG_CMD_EFFECTS required by Linux's NVMe device driver.

Also, off-by-one memory allocation issue has been addressed.

I believe this will fix #6.

Thanks.