### PR TITLE
Fix support for rmmod

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -192,7 +192,7 @@ static void __nvmev_admin_get_log_page(int eid, int cq_head)
 
 	switch (cmd->lid) {
 	case NVME_LOG_SMART: {
-		struct nvme_smart_log smart_log = {
+		static const struct nvme_smart_log smart_log = {
 			.critical_warning = 0,
 			.spare_thresh = 20,
 			.host_reads[0] = cpu_to_le64(0),
@@ -208,7 +208,7 @@ static void __nvmev_admin_get_log_page(int eid, int cq_head)
 		break;
 	}
 	case NVME_LOG_CMD_EFFECTS: {
-		struct nvme_effects_log effects_log = {
+		static const struct nvme_effects_log effects_log = {
 			.acs = {
 				[nvme_admin_get_log_page] = cpu_to_le32(NVME_CMD_EFFECTS_CSUPP),
 				[nvme_admin_identify] = cpu_to_le32(NVME_CMD_EFFECTS_CSUPP),

--- a/conv_ftl.c
+++ b/conv_ftl.c
@@ -401,6 +401,7 @@ void conv_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *
 
 	/* PCIe, Write buffer are shared by all instances*/
 	for (i = 1; i < nr_parts; i++) {
+		kfree(conv_ftls[i].ssd->pcie->perf_model);
 		kfree(conv_ftls[i].ssd->pcie);
 		kfree(conv_ftls[i].ssd->write_buffer);
 

--- a/conv_ftl.h
+++ b/conv_ftl.h
@@ -86,6 +86,8 @@ struct conv_ftl {
 void conv_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *mapped_addr,
 			 uint32_t cpu_nr_dispatcher);
 
+void conv_remove_namespace(struct nvmev_ns *ns);
+
 bool conv_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req,
 			   struct nvmev_result *ret);
 

--- a/dma.c
+++ b/dma.c
@@ -122,6 +122,7 @@ static int ioat_dma_add_channel(struct ioat_dma_info *info, struct dma_chan *cha
 	struct dma_device *dma_dev = chan->device;
 	unsigned int thread_count = 0;
 
+	// XXX: No corresponding kfree() yet
 	dtc = kmalloc(sizeof(struct ioat_dma_chan), GFP_KERNEL);
 	if (!dtc) {
 		pr_warn("No memory for %s\n", dma_chan_name(chan));

--- a/kv_ftl.c
+++ b/kv_ftl.c
@@ -1073,3 +1073,9 @@ void kv_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *ma
 
 	return;
 }
+
+void kv_remove_namespace(struct nvmev_ns *ns)
+{
+	kfree(ns->ftls);
+	ns->ftls = NULL;
+}

--- a/kv_ftl.h
+++ b/kv_ftl.h
@@ -205,5 +205,6 @@ bool kv_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req, struct 
 unsigned int kv_perform_io_cmd(struct nvmev_ns *ns, struct nvme_command *cmd, uint32_t *status);
 void kv_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *mapped_addr,
 		       uint32_t cpu_nr_dispatcher);
+void kv_remove_namespace(struct nvmev_ns *ns);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -613,24 +613,25 @@ ret_err:
 
 static void NVMeV_exit(void)
 {
+	int i;
+
+	if (nvmev_vdev->virt_bus != NULL)
+		pci_remove_root_bus(nvmev_vdev->virt_bus);
+
 	NVMEV_REG_PROC_FINAL(nvmev_vdev);
 	NVMEV_IO_PROC_FINAL(nvmev_vdev);
 
 	NVMEV_NAMESPACE_FINAL(nvmev_vdev);
 	NVMEV_STORAGE_FINAL(nvmev_vdev);
 
-	if (nvmev_vdev->virt_bus != NULL) {
-		int i;
-		pci_remove_root_bus(nvmev_vdev->virt_bus);
-
-		for (i = 0; i < nvmev_vdev->nr_sq; i++) {
-			kfree(nvmev_vdev->sqes[i]);
-		}
-
-		for (i = 0; i < nvmev_vdev->nr_cq; i++) {
-			kfree(nvmev_vdev->cqes[i]);
-		}
+	for (i = 0; i < nvmev_vdev->nr_sq; i++) {
+		kfree(nvmev_vdev->sqes[i]);
 	}
+
+	for (i = 0; i < nvmev_vdev->nr_cq; i++) {
+		kfree(nvmev_vdev->cqes[i]);
+	}
+
 	VDEV_FINALIZE(nvmev_vdev);
 
 	NVMEV_INFO("Virtual NVMe device closed\n");

--- a/main.c
+++ b/main.c
@@ -615,8 +615,10 @@ static void NVMeV_exit(void)
 {
 	int i;
 
-	if (nvmev_vdev->virt_bus != NULL)
+	if (nvmev_vdev->virt_bus != NULL) {
+		pci_stop_root_bus(nvmev_vdev->virt_bus);
 		pci_remove_root_bus(nvmev_vdev->virt_bus);
+	}
 
 	NVMEV_REG_PROC_FINAL(nvmev_vdev);
 	NVMEV_IO_PROC_FINAL(nvmev_vdev);

--- a/pci.c
+++ b/pci.c
@@ -451,6 +451,12 @@ void VDEV_FINALIZE(struct nvmev_dev *nvmev_vdev)
 	if (nvmev_vdev->old_dbs)
 		kfree(nvmev_vdev->old_dbs);
 
+	if (nvmev_vdev->admin_q->nvme_cq)
+		kfree(nvmev_vdev->admin_q->nvme_cq);
+
+	if (nvmev_vdev->admin_q->nvme_sq)
+		kfree(nvmev_vdev->admin_q->nvme_sq);
+
 	if (nvmev_vdev->admin_q)
 		kfree(nvmev_vdev->admin_q);
 

--- a/pci.c
+++ b/pci.c
@@ -463,9 +463,6 @@ void VDEV_FINALIZE(struct nvmev_dev *nvmev_vdev)
 	if (nvmev_vdev->virtDev)
 		kfree(nvmev_vdev->virtDev);
 
-	if (nvmev_vdev->io_unit_stat)
-		kfree(nvmev_vdev->io_unit_stat);
-
 	if (nvmev_vdev)
 		kfree(nvmev_vdev);
 }

--- a/simple_ftl.c
+++ b/simple_ftl.c
@@ -122,3 +122,8 @@ void simple_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void
 
 	return;
 }
+
+void simple_remove_namespace(struct nvmev_ns *ns)
+{
+	// Nothing to do here
+}

--- a/simple_ftl.h
+++ b/simple_ftl.h
@@ -25,5 +25,6 @@ bool simple_proc_nvme_io_cmd(struct nvmev_ns *ns, struct nvmev_request *req,
 			     struct nvmev_result *ret);
 void simple_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *mapped_addr,
 			   uint32_t cpu_nr_dispatcher);
+void simple_remove_namespace(struct nvmev_ns *ns);
 
 #endif

--- a/ssd.h
+++ b/ssd.h
@@ -267,6 +267,7 @@ static inline uint32_t get_cell(struct ssd *ssd, struct ppa *ppa)
 
 void ssd_init_params(struct ssdparams *spp, uint64_t capacity, uint32_t nparts);
 void ssd_init(struct ssd *ssd, struct ssdparams *spp, uint32_t cpu_nr_dispatcher);
+void ssd_remove(struct ssd *ssd);
 
 uint64_t ssd_advance_nand(struct ssd *ssd, struct nand_cmd *ncmd);
 uint64_t ssd_advance_pcie(struct ssd *ssd, uint64_t request_time, uint64_t length);

--- a/zns_ftl.c
+++ b/zns_ftl.c
@@ -53,6 +53,13 @@ static void __init_descriptor(struct zns_ftl *zns_ftl)
 	}
 }
 
+static void __remove_descriptor(struct zns_ftl *zns_ftl)
+{
+	kfree(zns_ftl->zwra_buffer);
+	kfree(zns_ftl->report_buffer);
+	kfree(zns_ftl->zone_descs);
+}
+
 static void __init_resource(struct zns_ftl *zns_ftl)
 {
 	struct zone_resource_info *res_infos = zns_ftl->res_infos;
@@ -133,12 +140,17 @@ void zns_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *m
 	return;
 }
 
-static void zns_exit(struct zns_ftl *zns_ftl)
+void zns_remove_namespace(struct nvmev_ns *ns)
 {
-	NVMEV_ZNS_DEBUG("%s \n", __FUNCTION__);
+	struct zns_ftl *zns_ftl = (struct zns_ftl *)ns->ftls;
 
-	kfree(zns_ftl->zone_descs);
-	kfree(zns_ftl->report_buffer);
+	ssd_remove(zns_ftl->ssd);
+
+	__remove_descriptor(zns_ftl);
+	kfree(zns_ftl->ssd);
+	kfree(zns_ftl);
+
+	ns->ftls = NULL;
 }
 
 static void zns_flush(struct nvmev_ns *ns, struct nvmev_request *req, struct nvmev_result *ret)

--- a/zns_ftl.h
+++ b/zns_ftl.h
@@ -139,6 +139,7 @@ static inline uint64_t lba_to_lpn(struct zns_ftl *zns_ftl, uint64_t lba)
 /* zns external interface */
 void zns_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *mapped_addr,
 			uint32_t cpu_nr_dispatcher);
+void zns_remove_namespace(struct nvmev_ns *ns);
 
 void zns_zmgmt_recv(struct nvmev_ns *ns, struct nvmev_request *req, struct nvmev_result *ret);
 void zns_zmgmt_send(struct nvmev_ns *ns, struct nvmev_request *req, struct nvmev_result *ret);


### PR DESCRIPTION
Fixes #1.

This PR adds missing resource frees and fixes some deregister code logic so that NVMe doesn't cause an I/O timeout during the rmmod.

This was successfully tested under a system with KASAN and kmemleak enabled. Both didn't report back any memory faults from switching all 4 supported configurations from NVMeVirt without any reboots in between.