### PR TITLE
Compat 6.8.y

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -564,6 +564,7 @@ static void __nvmev_proc_admin_req(int entry_id)
 		break;
 	case nvme_admin_identify:
 		__nvmev_admin_identify(entry_id);
+		break;
 	case nvme_admin_abort_cmd:
 		break;
 	case nvme_admin_set_features:

--- a/append_only.c
+++ b/append_only.c
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "nvmev.h"
 #include <linux/bitmap.h>
-#include <linux/types.h>
 #include <asm/bitops.h>
 #include <linux/log2.h>
 #include <linux/hashtable.h>
 #include <linux/kernel.h>
+
+#include "nvmev.h"
+#include "append_only.h"
 
 static unsigned long long latest;
 static unsigned long long dev_size;

--- a/conv_ftl.c
+++ b/conv_ftl.c
@@ -6,9 +6,6 @@
 #include "nvmev.h"
 #include "conv_ftl.h"
 
-void schedule_internal_operation(int sqid, unsigned long long nsecs_target,
-				 struct buffer *write_buffer, unsigned int buffs_to_release);
-
 static inline bool last_pg_in_wordline(struct conv_ftl *conv_ftl, struct ppa *ppa)
 {
 	struct ssdparams *spp = &conv_ftl->ssd->sp;

--- a/dma.c
+++ b/dma.c
@@ -248,8 +248,8 @@ static void add_threaded_dma(struct ioat_dma_info *info)
 
 	/* Copy test parameters */
 	params->buf_size = test_buf_size;
-	strlcpy(params->channel, strim(test_channel), sizeof(params->channel));
-	strlcpy(params->device, strim(test_device), sizeof(params->device));
+	strscpy(params->channel, strim(test_channel), sizeof(params->channel));
+	strscpy(params->device, strim(test_device), sizeof(params->device));
 	params->max_channels = max_channels;
 	params->timeout = timeout;
 	params->transfer_size = transfer_size;

--- a/dma.c
+++ b/dma.c
@@ -9,6 +9,8 @@
 #include <linux/sched/task.h>
 #include <linux/slab.h>
 
+#include "dma.h"
+
 // Size of the memcpy test buffer
 static unsigned int test_buf_size = 4096;
 

--- a/kv_ftl.c
+++ b/kv_ftl.c
@@ -796,7 +796,7 @@ static unsigned int __do_perform_kv_batch(struct kv_ftl *kv_ftl, struct nvme_kv_
 	return 0;
 }
 
-unsigned int kv_iter_open(struct kv_ftl *kv_ftl, struct nvme_kv_command cmd, unsigned int *status)
+static unsigned int kv_iter_open(struct kv_ftl *kv_ftl, struct nvme_kv_command cmd, unsigned int *status)
 {
 	int iter = 0;
 	bool flag = false;
@@ -824,7 +824,7 @@ unsigned int kv_iter_open(struct kv_ftl *kv_ftl, struct nvme_kv_command cmd, uns
 	return iter;
 }
 
-unsigned int kv_iter_close(struct kv_ftl *kv_ftl, struct nvme_kv_command cmd, unsigned int *status)
+static unsigned int kv_iter_close(struct kv_ftl *kv_ftl, struct nvme_kv_command cmd, unsigned int *status)
 {
 	int iter = cmd.kv_iter_req.iter_handle;
 

--- a/main.c
+++ b/main.c
@@ -408,7 +408,7 @@ static const struct file_operations proc_file_fops = {
 };
 #endif
 
-void NVMEV_STORAGE_INIT(struct nvmev_dev *nvmev_vdev)
+static void NVMEV_STORAGE_INIT(struct nvmev_dev *nvmev_vdev)
 {
 	NVMEV_INFO("Storage: %#010lx-%#010lx (%lu MiB)\n",
 			nvmev_vdev->config.storage_start,
@@ -435,7 +435,7 @@ void NVMEV_STORAGE_INIT(struct nvmev_dev *nvmev_vdev)
 	nvmev_vdev->proc_debug = proc_create("debug", 0444, nvmev_vdev->proc_root, &proc_file_fops);
 }
 
-void NVMEV_STORAGE_FINAL(struct nvmev_dev *nvmev_vdev)
+static void NVMEV_STORAGE_FINAL(struct nvmev_dev *nvmev_vdev)
 {
 	remove_proc_entry("read_times", nvmev_vdev->proc_root);
 	remove_proc_entry("write_times", nvmev_vdev->proc_root);
@@ -498,7 +498,7 @@ static bool __load_configs(struct nvmev_config *config)
 	return true;
 }
 
-void NVMEV_NAMESPACE_INIT(struct nvmev_dev *nvmev_vdev)
+static void NVMEV_NAMESPACE_INIT(struct nvmev_dev *nvmev_vdev)
 {
 	unsigned long long remaining_capacity = nvmev_vdev->config.storage_size;
 	void *ns_addr = nvmev_vdev->storage_mapped;
@@ -536,7 +536,7 @@ void NVMEV_NAMESPACE_INIT(struct nvmev_dev *nvmev_vdev)
 	nvmev_vdev->mdts = MDTS;
 }
 
-void NVMEV_NAMESPACE_FINAL(struct nvmev_dev *nvmev_vdev)
+static void NVMEV_NAMESPACE_FINAL(struct nvmev_dev *nvmev_vdev)
 {
 	struct nvmev_ns *ns = nvmev_vdev->ns;
 	const int nr_ns = NR_NAMESPACES; // XXX: allow for dynamic nvmev_vdev->nr_ns

--- a/nvmev.h
+++ b/nvmev.h
@@ -295,6 +295,9 @@ void nvmev_proc_admin_sq(int new_db, int old_db);
 void nvmev_proc_admin_cq(int new_db, int old_db);
 
 // OPS I/O QUEUE
+struct buffer;
+void schedule_internal_operation(int sqid, unsigned long long nsecs_target,
+				struct buffer *write_buffer, size_t buffs_to_release);
 void NVMEV_IO_WORKER_INIT(struct nvmev_dev *nvmev_vdev);
 void NVMEV_IO_WORKER_FINAL(struct nvmev_dev *nvmev_vdev);
 int nvmev_proc_io_sq(int qid, int new_db, int old_db);

--- a/pci.c
+++ b/pci.c
@@ -257,7 +257,7 @@ out:
 	return;
 }
 
-int nvmev_pci_read(struct pci_bus *bus, unsigned int devfn, int where, int size, u32 *val)
+static int nvmev_pci_read(struct pci_bus *bus, unsigned int devfn, int where, int size, u32 *val)
 {
 	if (devfn != 0)
 		return 1;
@@ -269,7 +269,7 @@ int nvmev_pci_read(struct pci_bus *bus, unsigned int devfn, int where, int size,
 	return 0;
 };
 
-int nvmev_pci_write(struct pci_bus *bus, unsigned int devfn, int where, int size, u32 _val)
+static int nvmev_pci_write(struct pci_bus *bus, unsigned int devfn, int where, int size, u32 _val)
 {
 	u32 mask = ~(0U);
 	u32 val = 0x00;

--- a/simple_ftl.c
+++ b/simple_ftl.c
@@ -3,7 +3,7 @@
 #include <linux/ktime.h>
 #include <linux/sched/clock.h>
 
-#include "nvmev.h"
+#include "simple_ftl.h"
 
 static inline unsigned long long __get_wallclock(void)
 {

--- a/zns_read_write.c
+++ b/zns_read_write.c
@@ -4,9 +4,6 @@
 #include "ssd.h"
 #include "zns_ftl.h"
 
-void schedule_internal_operation(int sqid, unsigned long long nsecs_target,
-				 struct buffer *write_buffer, size_t buffs_to_release);
-
 static inline uint32_t __nr_lbas_from_rw_cmd(struct nvme_rw_command *cmd)
 {
 	return cmd->length + 1;


### PR DESCRIPTION
This adds support for Linux kernel v6.8.

After these minor fixes, NVMeVirt works correctly on v6.8.