### PR TITLE
Efficient polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ $ sudo insmod ./nvmev.ko \
 
 In the above example, `memmap_start` and `memmap_size` indicate the relative offset and the size of the reserved memory, respectively. Those values should match the configurations specified in the `/etc/default/grub` file shown earlier. In addition, the `cpus` option specifies the id of cores on which I/O dispatcher and I/O worker threads run. You have to specify at least two cores for this purpose: one for the I/O dispatcher thread, and one or more cores for the I/O worker thread(s).
 
+It is highly recommended to use the `isolcpus` Linux command-line configuration to avoid schedulers putting tasks on the CPUs that NVMeVirt uses:
+
+```bash
+GRUB_CMDLINE_LINUX="memmap=64G\\\$128G isolcpus=7,8"
+```
+
 When you are successfully load the `nvmevirt` module, you can see something like these from the system message.
 
 ```log

--- a/nvmev.h
+++ b/nvmev.h
@@ -16,6 +16,19 @@
 #undef CONFIG_NVMEV_DEBUG
 #undef CONFIG_NVMEV_DEBUG_VERBOSE
 
+/*
+ * If CONFIG_NVMEVIRT_IDLE_TIMEOUT is set, sleep for a jiffie after
+ * CONFIG_NVMEVIRT_IDLE_TIMEOUT seconds have passed to lower CPU power
+ * consumption on idle.
+ *
+ * This may introduce a (1000/CONFIG_HZ) ms processing latency penalty
+ * when exiting an I/O idle state.
+ *
+ * The default is set to 60 seconds, which is extremely conservative and
+ * should not have an impact on I/O testing.
+ */
+#define CONFIG_NVMEVIRT_IDLE_TIMEOUT 60
+
 /*************************/
 #define NVMEV_DRV_NAME "NVMeVirt"
 #define NVMEV_VERSION 0x0110
@@ -286,7 +299,7 @@ struct nvmev_dev *VDEV_INIT(void);
 void VDEV_FINALIZE(struct nvmev_dev *nvmev_vdev);
 
 // OPS_PCI
-void nvmev_proc_bars(void);
+bool nvmev_proc_bars(void);
 bool NVMEV_PCI_INIT(struct nvmev_dev *dev);
 void nvmev_signal_irq(int msi_index);
 

--- a/pci.c
+++ b/pci.c
@@ -94,8 +94,10 @@ void nvmev_signal_irq(int msi_index)
  *
  * Also, memory barrier is not necessary here since BAR-related
  * operations are only processed by the dispatcher.
+ *
+ * Returns true if an event is processed.
  */
-void nvmev_proc_bars(void)
+bool nvmev_proc_bars(void)
 {
 	volatile struct __nvme_bar *old_bar = nvmev_vdev->old_bar;
 	volatile struct nvme_ctrl_regs *bar = nvmev_vdev->bar;
@@ -252,9 +254,12 @@ void nvmev_proc_bars(void)
 
 		goto out;
 	}
+
+	return false;
+
 out:
 	smp_mb();
-	return;
+	return true;
 }
 
 static int nvmev_pci_read(struct pci_bus *bus, unsigned int devfn, int where, int size, u32 *val)


### PR DESCRIPTION
We noticed a workload performance fluctuation due to previous instance
of NVMeVirt causing turbo expiration (PL) from the CPU with excessive
polling.

Introducing a basic idle state within NVMeVirt works around this issue.

If CONFIG_NVMEVIRT_IDLE_TIMEOUT is set, sleep for a jiffie after
CONFIG_NVMEVIRT_IDLE_TIMEOUT seconds have passed to lower CPU power
consumption on idle.

This may introduce a (1000/CONFIG_HZ) ms processing latency penalty
when exiting an I/O idle state.

The default is set to 60 seconds, which is extremely conservative and
should not have an impact on I/O testing.