### PR TITLE
ZNS fixes

### DIFF
--- a/zns_ftl.c
+++ b/zns_ftl.c
@@ -45,8 +45,8 @@ static void __init_descriptor(struct zns_ftl *zns_ftl)
 		if (zone_wb_size)
 			buffer_init(&(zns_ftl->zone_write_buffer[i]), zone_wb_size);
 
-		NVMEV_ZNS_DEBUG("[i] zslba 0x%llx zone capacity 0x%llx\n", zone_descs[i].zslba,
-				zone_descs[i].zone_capacity);
+		NVMEV_ZNS_DEBUG("[%d] zslba 0x%llx zone capacity 0x%llx, wp 0x%llx\n", i,
+			zone_descs[i].zslba, zone_descs[i].zone_capacity, zone_descs[i].wp);
 	}
 }
 

--- a/zns_ftl.c
+++ b/zns_ftl.c
@@ -17,7 +17,7 @@ static void __init_descriptor(struct zns_ftl *zns_ftl)
 	const uint32_t zrwa_buffer_size = zns_ftl->zp.zrwa_buffer_size;
 	const uint32_t zone_wb_size = zns_ftl->zp.zone_wb_size;
 
-	zns_ftl->zone_descs = kmalloc(sizeof(struct zone_descriptor) * nr_zones, GFP_KERNEL);
+	zns_ftl->zone_descs = kzalloc(sizeof(struct zone_descriptor) * nr_zones, GFP_KERNEL);
 	zns_ftl->report_buffer = kmalloc(
 		sizeof(struct zone_report) + sizeof(struct zone_descriptor) * nr_zones, GFP_KERNEL);
 
@@ -28,7 +28,6 @@ static void __init_descriptor(struct zns_ftl *zns_ftl)
 		zns_ftl->zone_write_buffer = kmalloc(sizeof(struct buffer) * nr_zones, GFP_KERNEL);
 
 	zone_descs = zns_ftl->zone_descs;
-	memset(zone_descs, 0, sizeof(struct zone_descriptor) * zns_ftl->zp.nr_zones);
 
 	for (i = 0; i < nr_zones; i++) {
 		zone_descs[i].state = ZONE_STATE_EMPTY;

--- a/zns_mgmt_recv.c
+++ b/zns_mgmt_recv.c
@@ -124,7 +124,7 @@ void zns_zmgmt_recv(struct nvmev_ns *ns, struct nvmev_request *req, struct nvmev
 	uint64_t length = (cmd->nr_dw + 1) * sizeof(uint32_t);
 	uint32_t status;
 
-	NVMEV_ZNS_DEBUG("%s slba 0x%llx nr_dw 0x%lx  action %u partial %u action_specific 0x%x\n",
+	NVMEV_ZNS_DEBUG("%s slba 0x%llx nr_dw 0x%llx  action %u partial %u action_specific 0x%x\n",
 			__func__, cmd->slba, length, cmd->zra, cmd->zra_specific_features,
 			cmd->zra_specific_field);
 

--- a/zns_mgmt_recv.c
+++ b/zns_mgmt_recv.c
@@ -86,6 +86,11 @@ static void __fill_zone_report(struct zns_ftl *zns_ftl, struct nvme_zone_mgmt_re
 	else // partial. # of zone desc transferred
 		nr_zone_to_report = (bytes_transfer / sizeof(struct zone_descriptor)) - 1;
 
+	if (nr_zone_to_report > zns_ftl->zp.nr_zones - start_zid) {
+		// Userspace asked for zones exceeding the device limit, adjust nr_zones
+		nr_zone_to_report = zns_ftl->zp.nr_zones - start_zid;
+	}
+
 	report->nr_zones = nr_zone_to_report;
 
 	memcpy(report->zd, &(zone_descs[start_zid]),

--- a/zns_mgmt_send.c
+++ b/zns_mgmt_send.c
@@ -111,8 +111,8 @@ static void __reset_zone(struct zns_ftl *zns_ftl, uint64_t zid)
 	uint32_t zone_size = zns_ftl->zp.zone_size;
 	uint8_t *zone_start_addr = (uint8_t *)get_storage_addr_from_zid(zns_ftl, zid);
 
-	NVMEV_ZNS_DEBUG("%s ns %d zid %lu start addres 0x%llx zone_size %x \n", __func__,
-			zns_ftl->ns, zid, (uint64_t)zone_start_addr, zone_size);
+	NVMEV_ZNS_DEBUG("%s zid %llu start addres 0x%llx zone_size %x \n", __func__,
+			zid, (uint64_t)zone_start_addr, zone_size);
 
 	memset(zone_start_addr, 0, zone_size);
 
@@ -276,7 +276,7 @@ void zns_zmgmt_send(struct nvmev_ns *ns, struct nvmev_request *req, struct nvmev
 		status = __zmgmt_send(zns_ftl, slba, action, option);
 	}
 
-	NVMEV_ZNS_DEBUG("%s slba %llx zid %lu select_all %lu action %u status %lu option %lu\n",
+	NVMEV_ZNS_DEBUG("%s slba %llx zid %llu select_all %u action %u status %u option %u\n",
 			__func__, cmd->slba, zid, select_all, cmd->zsa, status, option);
 
 	ret->nsecs_target = req->nsecs_start; // no delay

--- a/zns_read_write.c
+++ b/zns_read_write.c
@@ -93,7 +93,7 @@ static bool __zns_write(struct zns_ftl *zns_ftl, struct nvmev_request *req,
 	elpn = lba_to_lpn(zns_ftl, slba + nr_lba - 1);
 	zone_elpn = zone_to_elpn(zns_ftl, zid);
 
-	NVMEV_ZNS_DEBUG("%s slba 0x%llx nr_lba 0x%lx zone_id %d state %d\n", __func__, slba,
+	NVMEV_ZNS_DEBUG("%s slba 0x%llx nr_lba 0x%llx zone_id %d state %d\n", __func__, slba,
 			nr_lba, zid, state);
 
 	if (zns_ftl->zp.zone_wb_size)
@@ -196,7 +196,7 @@ static bool __zns_write(struct zns_ftl *zns_ftl, struct nvmev_request *req,
 			uint64_t nsecs_completed = ssd_advance_nand(zns_ftl->ssd, &swr);
 
 			nsecs_latest = max(nsecs_completed, nsecs_latest);
-			NVMEV_ZNS_DEBUG("%s Flush slba 0x%llx nr_lba 0x%lx zone_id %d state %d\n",
+			NVMEV_ZNS_DEBUG("%s Flush slba 0x%llx nr_lba 0x%llx zone_id %d state %d\n",
 					__func__, slba, nr_lba, zid, state);
 
 			if (((lpn + pgs - 1) == zone_elpn) && (unaligned_space > 0))
@@ -419,7 +419,7 @@ bool zns_read(struct nvmev_ns *ns, struct nvmev_request *req, struct nvmev_resul
 	struct nand_cmd swr;
 
 	NVMEV_ZNS_DEBUG(
-		"%s slba 0x%llx nr_lba 0x%lx zone_id %d state %d wp 0x%llx last lba 0x%llx\n",
+		"%s slba 0x%llx nr_lba 0x%llx zone_id %d state %d wp 0x%llx last lba 0x%llx\n",
 		__func__, slba, nr_lba, zid, zone_descs[zid].state, zone_descs[zid].wp,
 		(slba + nr_lba - 1));
 


### PR DESCRIPTION
This PR mainly fixes BLKREPORTZONE ioctl() call on a virtually mapped NVMeVirt ZNS instance.