### PR TITLE
Convert irq_lock to mutex

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -69,7 +69,7 @@ static void __nvmev_admin_create_cq(int eid)
 	cq->cq_tail = -1;
 
 	spin_lock_init(&cq->entry_lock);
-	spin_lock_init(&cq->irq_lock);
+	mutex_init(&cq->irq_lock);
 
 	/* TODO Physically non-contiguous prp list */
 	cq->phys_contig = cmd->cq_flags & NVME_QUEUE_PHYS_CONTIG ? true : false;

--- a/io.c
+++ b/io.c
@@ -650,7 +650,7 @@ static int nvmev_io_worker(void *data)
 			if (cq == NULL || !cq->irq_enabled)
 				continue;
 
-			if (spin_trylock(&cq->irq_lock)) {
+			if (mutex_trylock(&cq->irq_lock)) {
 				if (cq->interrupt_ready == true) {
 #ifdef PERF_DEBUG
 					prev_clock = local_clock();
@@ -670,7 +670,7 @@ static int nvmev_io_worker(void *data)
 					}
 #endif
 				}
-				spin_unlock(&cq->irq_lock);
+				mutex_unlock(&cq->irq_lock);
 			}
 		}
 		cond_resched();

--- a/nvmev.h
+++ b/nvmev.h
@@ -99,7 +99,7 @@ struct nvmev_completion_queue {
 	bool phys_contig;
 
 	spinlock_t entry_lock;
-	spinlock_t irq_lock;
+	struct mutex irq_lock;
 
 	int queue_size;
 


### PR DESCRIPTION
MSI helper functions within the Linux kernel may try to catch mutex [1][2] while we hold a spinlock with preemption disabled.

Fixes: #30
Link: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/irq/msi.c?h=v6.6#n448 [1]
Link: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/irq/msi.c?h=v6.6#n334 [2]