### PR TITLE
ssd: Invoke an assertion error w/ large alloc size

### DIFF
--- a/ssd.c
+++ b/ssd.c
@@ -20,6 +20,8 @@ void buffer_init(struct buffer *buf, size_t size)
 
 uint32_t buffer_allocate(struct buffer *buf, size_t size)
 {
+	NVMEV_ASSERT(size <= buf->size);
+
 	while (!spin_trylock(&buf->lock)) {
 		cpu_relax();
 	}


### PR DESCRIPTION
When the allocation size exceeds the write buffer size, NVMeVirt retries the command infinitely many times. Thus, we need to invoke an assertion error in that case.