### PR TITLE
Disable `E820_TYPE_RESERVED_KERN` check for Linux 6.15+

### DIFF
--- a/main.c
+++ b/main.c
@@ -213,8 +213,11 @@ static int __validate_configs_arch(void)
 	resv_start_bytes = memmap_start;
 	resv_end_bytes = resv_start_bytes + memmap_size - 1;
 
-	if (e820__mapped_any(resv_start_bytes, resv_end_bytes, E820_TYPE_RAM) ||
-	    e820__mapped_any(resv_start_bytes, resv_end_bytes, E820_TYPE_RESERVED_KERN)) {
+	if (e820__mapped_any(resv_start_bytes, resv_end_bytes, E820_TYPE_RAM)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+	    || e820__mapped_any(resv_start_bytes, resv_end_bytes, E820_TYPE_RESERVED_KERN)
+#endif
+	) {
 		NVMEV_ERROR("[mem %#010lx-%#010lx] is usable, not reseved region\n",
 			    (unsigned long)resv_start_bytes, (unsigned long)resv_end_bytes);
 		return -EPERM;


### PR DESCRIPTION
[Starting from Linux 6.15+, the `E820_TYPE_RESERVED_KERN` constant has been removed from `enum e820_type`](https://lore.kernel.org/r/20250214090651.3331663-5-rppt@kernel.org), which produces the following error when trying to compile `nvmevirt`:

```
make -C /lib/modules/6.18.2-1-default/build M=/home/jdeokkim/Workspace/nvmevirt modules
make[1]: Entering directory '/usr/src/linux-6.18.2-1-obj/x86_64/default'
make[2]: Entering directory '/home/jdeokkim/Workspace/nvmevirt'
  CC [M]  main.o
main.c: In function ‘__validate_configs_arch’:
main.c:217:64: error: ‘E820_TYPE_RESERVED_KERN’ undeclared (first use in this function); did you mean ‘E820_TYPE_RESERVED’?
  217 |             e820__mapped_any(resv_start_bytes, resv_end_bytes, E820_TYPE_RESERVED_KERN)) {
      |                                                                ^~~~~~~~~~~~~~~~~~~~~~~
      |                                                                E820_TYPE_RESERVED
main.c:217:64: note: each undeclared identifier is reported only once for each function it appears in
make[4]: *** [/usr/src/linux-6.18.2-1/scripts/Makefile.build:287: main.o] Error 1
make[3]: *** [/usr/src/linux-6.18.2-1/Makefile:2033: .] Error 2
make[2]: *** [/usr/src/linux-6.18.2-1/Makefile:248: __sub-make] Error 2
make[2]: Leaving directory '/home/jdeokkim/Workspace/nvmevirt'
make[1]: *** [../../../linux-6.18.2-1/Makefile:248: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-6.18.2-1-obj/x86_64/default'
make: *** [Makefile:8: default] Error 2
```

---

This pull request introduces a workaround for the issue mentioned above (https://github.com/snu-csl/nvmevirt/issues/67).

```
make -C /lib/modules/6.18.2-1-default/build M=/home/jdeokkim/Workspace/nvmevirt modules
make[1]: Entering directory '/usr/src/linux-6.18.2-1-obj/x86_64/default'
make[2]: Entering directory '/home/jdeokkim/Workspace/nvmevirt'
  CC [M]  main.o
  CC [M]  pci.o
  CC [M]  admin.o
  CC [M]  io.o
  CC [M]  dma.o
  CC [M]  simple_ftl.o
  LD [M]  nvmev.o
  MODPOST Module.symvers
WARNING: modpost: missing MODULE_DESCRIPTION() in nvmev.o
  CC [M]  nvmev.mod.o
  CC [M]  .module-common.o
  LD [M]  nvmev.ko
  BTF [M] nvmev.ko
Skipping BTF generation for nvmev.ko due to unavailability of vmlinux
make[2]: Leaving directory '/home/jdeokkim/Workspace/nvmevirt'
make[1]: Leaving directory '/usr/src/linux-6.18.2-1-obj/x86_64/default'
```

<details>
  <summary>Kernel Ring Buffer Messages (<code>dmesg</code>)</summary>

```console
$ cat /proc/cmdline
BOOT_IMAGE=/boot/vmlinuz-6.18.2-1-default root=UUID=888c106b-9330-4822-b185-71e17a12100e memmap=4G$12G isolcpus=6,7 memmap=4G$12G isolcpus=6,7
```

```
[  105.800084] [   T3286] nvmev: loading out-of-tree module taints kernel.
[  105.800091] [   T3286] nvmev: module verification failed: signature and/or required key missing - tainting kernel
[  105.800616] [   T3286] NVMeVirt: Version 1.10 for >> NVM SSD <<
[  105.800620] [   T3286] NVMeVirt: Storage: 0x300100000-0x400000000 (4095 MiB)
[  105.803861] [   T3286] NVMeVirt: ns 0/1: size 4095 MiB
[  105.803896] [   T3286] PCI host bridge to bus 0001:10
[  105.803898] [   T3286] pci_bus 0001:10: root bus resource [io  0x0000-0xffff]
[  105.803900] [   T3286] pci_bus 0001:10: root bus resource [mem 0x00000000-0x7fffffffff]
[  105.803902] [   T3286] pci_bus 0001:10: root bus resource [bus 00-ff]
[  105.803909] [   T3286] pci 0001:10:00.0: [0c51:0110] type 00 class 0x010802 PCIe Endpoint
[  105.803912] [   T3286] pci 0001:10:00.0: BAR 0 [mem 0x300000000-0x300003fff 64bit]
[  105.803914] [   T3286] pci 0001:10:00.0: enabling Extended Tags
[  105.804019] [   T3286] NVMeVirt: Virtual PCI bus created (node 0)
[  105.804179] [   T3287] NVMeVirt: nvmev_io_worker_0 started on cpu 7 (node 0)
[  105.804225] [   T3288] NVMeVirt: nvmev_dispatcher started on cpu 6 (node 0)
[  105.804240] [   T3286] NVMeVirt: Virtual NVMe device created
```
</details>