### PR TITLE
fix: add E820_TYPE_RESERVED_KERN check and fixed access out-of-bound bug

### DIFF
--- a/io.c
+++ b/io.c
@@ -542,11 +542,11 @@ void nvmev_proc_io_cq(int cqid, int new_db, int old_db)
 	struct nvmev_completion_queue *cq = nvmev_vdev->cqes[cqid];
 	int i;
 	for (i = old_db; i != new_db; i++) {
-		int sqid = cq_entry(i).sq_id;
 		if (i >= cq->queue_size) {
 			i = -1;
 			continue;
 		}
+		int sqid = cq_entry(i).sq_id;
 
 		/* Should check the validity here since SPDK deletes SQ immediately
 		 * before processing associated CQes */


### PR DESCRIPTION
1. latest kernel has removed E820_TYPE_RESERVED_KERN: https://lore.kernel.org/all/20250214090651.3331663-5-rppt@kernel.org/
2. I triggered a bug using nvmevirt:
   `[   46.312021] BUG: KASAN: slab-out-of-bounds in nvmev_proc_io_cq+0x282/0x2d0 [nvmev]`
   which is fixed in this patch by moving the access of `cq_entry(i)` after the checking of `i`